### PR TITLE
ci: publish container images to GHCR

### DIFF
--- a/.github/workflows/ghcr-release.yml
+++ b/.github/workflows/ghcr-release.yml
@@ -1,0 +1,66 @@
+name: Build and publish container images to GHCR
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ${{ github.repository_owner }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [baseos, ccenv, peer, orderer, tools, vscc]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set image name
+        run: |
+          echo "IMAGE_NAME=${REGISTRY}/${IMAGE_NAMESPACE}/drunix-${{ matrix.image }}" | tr '[:upper:]' '[:lower:]' >> "$GITHUB_ENV"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=sha
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: images/${{ matrix.image }}/Dockerfile
+          push: true
+          build-args: |
+            UBUNTU_VER=22.04
+            GO_VER=1.26.1
+            DRUNIX_VER=1.0.0
+            TARGETOS=linux
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Adds a GitHub Actions workflow to build and publish Drunix
container images to GitHub Container Registry (GHCR).

1. [x] 1. Validation performed:
2. [x] 2. - actionlint validation passed
3. [x] 3. - Successfully built all release images locally: