### PR TITLE
fix: guard nil metrics in lite peer ApplyUpdates skip path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Skip claude
+.claude*
+CLAUDE.md
+
+# Skip Intellij
+.idea/
+*.iml
+*.iws

--- a/core/ledger/kvledger/txmgmt/statedb/statesqldb/statesqldb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statesqldb/statesqldb.go
@@ -1,9 +1,8 @@
 /*
 Copyright National Payments Corporation of India. All Rights Reserved.
- 
+
 SPDX-License-Identifier: Apache-2.0
 */
-
 
 package statesqldb
 
@@ -243,6 +242,10 @@ func (db *versionedDB) ExecuteQueryWithPagination(namespace, query, bookmark str
 func (db *versionedDB) ApplyUpdates(batch *statedb.UpdateBatch, height *version.Height) error {
 	// DRUNIX : if litepeer enabled don't write to state database
 	if db.litePeerEnabled {
+		logger.Debugw("ApplyUpdates skipped: lite peer does not write to state database", "blockNum", height.BlockNum, "txNum", height.TxNum)
+		if db.metrics != nil {
+			db.metrics.DBCallSql.With("method_name", "ApplyUpdates", "call_type", "LitePeerSkip", "status", "skip").Add(1)
+		}
 		return nil
 	}
 	isLifecycleUpdate := false


### PR DESCRIPTION
## TL;DR                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
`versionedDB.ApplyUpdates` calls `db.metrics.DBCallSql...Add(1)` unconditionally on the lite-peer skip path, but `db.metrics` is nil whenever a caller passes a nil metrics provider (e.g. `core/vscc/validate.go`) — a lite peer taking that path would panic. Guards the call with a nil check and logs the skip at debug level instead.                                                                                                                                        
        
## Links

- Fixes #14