### PR TITLE
Fix nil metrics panic in VSCC SQL state DB writes

### DIFF
--- a/core/ledger/kvledger/txmgmt/statedb/statesqldb/statesqldb.go
+++ b/core/ledger/kvledger/txmgmt/statedb/statesqldb/statesqldb.go
@@ -292,12 +292,16 @@ func (db *versionedDB) ApplyUpdates(batch *statedb.UpdateBatch, height *version.
 			startTime := time.Now()
 			err := db.sqlSchema.Set(updateData)
 			if err != nil {
-				db.metrics.DBCallSql.With("method_name", "ApplyUpdates", "call_type", "Set", "status", "fail").Add(1)
-				db.metrics.DBCallTimeSQL.With("method_name", "ApplyUpdates", "call_type", "Set", "status", "fail").Observe(time.Since(startTime).Seconds())
+				if db.metrics != nil {
+					db.metrics.DBCallSql.With("method_name", "ApplyUpdates", "call_type", "Set", "status", "fail").Add(1)
+					db.metrics.DBCallTimeSQL.With("method_name", "ApplyUpdates", "call_type", "Set", "status", "fail").Observe(time.Since(startTime).Seconds())
+				}
 				logger.Errorf("Error in batch sql write. err:%+v", err)
 			}
-			db.metrics.DBCallSql.With("method_name", "ApplyUpdates", "call_type", "Set", "status", "success").Add(1)
-			db.metrics.DBCallTimeSQL.With("method_name", "ApplyUpdates", "call_type", "Set", "status", "success").Observe(time.Since(startTime).Seconds())
+			if db.metrics != nil {
+				db.metrics.DBCallSql.With("method_name", "ApplyUpdates", "call_type", "Set", "status", "success").Add(1)
+				db.metrics.DBCallTimeSQL.With("method_name", "ApplyUpdates", "call_type", "Set", "status", "success").Observe(time.Since(startTime).Seconds())
+			}
 			errChan <- err
 			wg.Done()
 		}()
@@ -309,12 +313,16 @@ func (db *versionedDB) ApplyUpdates(batch *statedb.UpdateBatch, height *version.
 			startTime := time.Now()
 			err := db.sqlSchema.Delete(deleteData)
 			if err != nil {
-				db.metrics.DBCallSql.With("method_name", "ApplyUpdates", "call_type", "Delete", "status", "fail").Add(1)
-				db.metrics.DBCallTimeSQL.With("method_name", "ApplyUpdates", "call_type", "Delete", "status", "fail").Observe(time.Since(startTime).Seconds())
+				if db.metrics != nil {
+					db.metrics.DBCallSql.With("method_name", "ApplyUpdates", "call_type", "Delete", "status", "fail").Add(1)
+					db.metrics.DBCallTimeSQL.With("method_name", "ApplyUpdates", "call_type", "Delete", "status", "fail").Observe(time.Since(startTime).Seconds())
+				}
 				logger.Errorf("Error in batch sql delete. err:%+v", err)
 			}
-			db.metrics.DBCallSql.With("method_name", "ApplyUpdates", "call_type", "Delete", "status", "success").Add(1)
-			db.metrics.DBCallTimeSQL.With("method_name", "ApplyUpdates", "call_type", "Delete", "status", "success").Observe(time.Since(startTime).Seconds())
+			if db.metrics != nil {
+				db.metrics.DBCallSql.With("method_name", "ApplyUpdates", "call_type", "Delete", "status", "success").Add(1)
+				db.metrics.DBCallTimeSQL.With("method_name", "ApplyUpdates", "call_type", "Delete", "status", "success").Observe(time.Since(startTime).Seconds())
+			}
 			errChan <- err
 			wg.Done()
 		}()
@@ -365,12 +373,16 @@ func (db *versionedDB) GetLatestSavePoint() (*version.Height, error) {
 	startTime := time.Now()
 	versionedValue, err := db.sqlSchema.Get(savePointKey)
 	if err != nil {
-		db.metrics.DBCallSql.With("method_name", "GetLatestSavePoint", "call_type", "GetLifecycleKeys", "status", "fail").Add(1)
-		db.metrics.DBCallTimeSQL.With("method_name", "GetLatestSavePoint", "call_type", "GetLifecycleKeys", "status", "fail").Observe(time.Since(startTime).Seconds())
+		if db.metrics != nil {
+			db.metrics.DBCallSql.With("method_name", "GetLatestSavePoint", "call_type", "GetLifecycleKeys", "status", "fail").Add(1)
+			db.metrics.DBCallTimeSQL.With("method_name", "GetLatestSavePoint", "call_type", "GetLifecycleKeys", "status", "fail").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, err
 	}
-	db.metrics.DBCallSql.With("method_name", "GetLatestSavePoint", "call_type", "GetLifecycleKeys", "status", "success").Add(1)
-	db.metrics.DBCallTimeSQL.With("method_name", "GetLatestSavePoint", "call_type", "GetLifecycleKeys", "status", "success").Observe(time.Since(startTime).Seconds())
+	if db.metrics != nil {
+		db.metrics.DBCallSql.With("method_name", "GetLatestSavePoint", "call_type", "GetLifecycleKeys", "status", "success").Add(1)
+		db.metrics.DBCallTimeSQL.With("method_name", "GetLatestSavePoint", "call_type", "GetLifecycleKeys", "status", "success").Observe(time.Since(startTime).Seconds())
+	}
 	if versionedValue == nil {
 		return nil, nil
 	}

--- a/core/vscc/validate.go
+++ b/core/vscc/validate.go
@@ -83,7 +83,7 @@ func NewVsccValidateServer(ledgerConfig *ledger.Config, validationPluginsByName 
 			return nil, err
 		}
 	} else if ledgerConfig.StateDBConfig.StateDatabase == ledger.SqlDB {
-		vdbProvider, err = statesqldb.NewVersionedDBProvider(ledgerConfig.StateDBConfig.SqlDB, nil, nil)
+		vdbProvider, err = statesqldb.NewVersionedDBProvider(ledgerConfig.StateDBConfig.SqlDB, metricsProvider, nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## TL;DR

VSCC initializes its SQL state DB provider with a `nil` metrics provider (`statesqldb.NewVersionedDBProvider(..., nil, nil)`), so `registerMetricsOnce.Do` never runs and `db.metrics` stays `nil`. `ApplyUpdates`/`GetLatestSavePoint` then dereference it unconditionally, panicking on the first block commit on any channel using the standalone VSCC service. Passes the real `metricsProvider` through at the call site and guards every `db.metrics` dereference so a nil provider (e.g. the snapshot-import path, which intentionally passes `nil`) degrades gracefully instead of crashing.

**Files to review (2, +25 / -13):**

| File | Why |
|---|---|
| `core/vscc/validate.go` *(start here)* | Root cause: `NewVersionedDBProvider` was called with `nil` instead of `metricsProvider`. |
| `core/ledger/kvledger/txmgmt/statedb/statesqldb/statesqldb.go` | Wraps every `db.metrics.*` call in `ApplyUpdates` and `GetLatestSavePoint` with a nil check. |

## Reviewer notes

- **Both the root cause and the guard are fixed.** `ImportFromSnapshot` calls `provider.newVersionedDB(dbName, nil, nil)` on purpose, so `db.metrics` can legitimately be `nil` outside VSCC too — the nil guards keep that path safe even though the VSCC call site is now correct.
- **No behavior change on the happy path.** When a metrics provider is present, metrics are recorded exactly as before; the guard only skips recording when `db.metrics` is `nil`.

## Links

- Fixes #7
